### PR TITLE
Fix: Remove Double ShippingCosts Check 

### DIFF
--- a/resources/views/GoogleAnalyticsTrackingCode.twig
+++ b/resources/views/GoogleAnalyticsTrackingCode.twig
@@ -18,7 +18,7 @@
     {% set shippingCosts = 0 %}
     {% set webstoreConfig = services.webstoreConfig.getWebstoreConfig() %}
     {% set useGross = config("GoogleAnalytics.submitGrossPrices") == "true" %}
-    
+
     {% if trackOrder %}
         {% set data = services.customer.getLatestOrder() %}
         {% if data is defined %}
@@ -58,17 +58,7 @@
                     });
                 {% endif %}
 
-                {% if item.typeId == 6 %}
-                    {% if useGross %}
-                        {% set shippingCosts = shippingCosts + item.amounts[0].priceGross %}
-                    {% else %}
-                        {% set shippingCosts = shippingCosts + item.amounts[0].priceNet %}
-                    {% endif %}
-                {% endif %}
-
             {% endfor %}
-
-
 
             ga('ecommerce:send');
         {% endif %}


### PR DESCRIPTION
@felixdausch  @fmutschler  
Der Standard Container sollte geändert werden, Script.Loader wäre hier eine bessere Option (eventuell sogar After Scripts Loaded). Außerdem müsste die Anleitung auch einmal aktualisiert werden. 

Ich habe jetzt bewusst in diesem PR auf eine Änderung des Containers verzichtet. Mein Fokus lag hier nur auf der doppelten Abfrage der shippingCosts. 